### PR TITLE
feat: automated timetable scraper with GitHub Actions cron job

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -1,0 +1,33 @@
+name: Scrape UiTM Timetable
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'  # runs 1st of every month at midnight
+  workflow_dispatch:       # allows manual trigger from GitHub UI
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Run scraper for all campuses
+        run: node testScripts/scraperAll.js
+
+      - name: Commit and push JSON files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add public/timetable/
+          git diff --staged --quiet || git commit -m "chore: update timetable data [$(date +'%Y-%m-%d')]"
+          git push

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -22,7 +22,7 @@ jobs:
         run: yarn install
 
       - name: Run scraper for all campuses
-        run: node testScripts/scraperAll.js
+        run: node scripts/scraperAll.js
 
       - name: Commit and push JSON files
         run: |

--- a/scripts/scraperAll.js
+++ b/scripts/scraperAll.js
@@ -1,0 +1,187 @@
+import axios from "axios";
+import * as cheerio from "cheerio";
+import { wrapper } from "axios-cookiejar-support";
+import { CookieJar } from "tough-cookie";
+import { writeFileSync, mkdirSync } from "fs";
+
+const BASE = "https://simsweb4.uitm.edu.my/estudent/class_timetable/";
+const OUTPUT_DIR = "./public/timetable";
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const CAMPUSES = [
+  { text: 'SELANGOR - LANGUAGE', id: 'APB' },
+  { text: 'SELANGOR - CITU', id: 'CITU' },
+  { text: 'SELANGOR - CO-CURRICULUM', id: 'HEP' },
+  { text: 'SERI ISKANDAR', id: 'A' },
+  { text: 'TAPAH', id: 'A4' },
+  { text: 'DENGKIL', id: 'B10' },
+  { text: 'JENGKA', id: 'C' },
+  { text: 'RAUB', id: 'C3' },
+  { text: 'MACHANG', id: 'D' },
+  { text: 'KOTA BHARU', id: 'D2' },
+  { text: 'SEGAMAT', id: 'J' },
+  { text: 'PASIR GUDANG', id: 'J4' },
+  { text: 'SUNGAI PETANI', id: 'K' },
+  { text: 'ALOR GAJAH', id: 'M' },
+  { text: 'BANDARAYA MELAKA', id: 'M1' },
+  { text: 'JASIN', id: 'M3' },
+  { text: 'KUALA PILAH', id: 'N' },
+  { text: 'KUALA PILAH 2', id: 'N3' },
+  { text: 'SEREMBAN 3', id: 'N4' },
+  { text: 'REMBAU', id: 'N5' },
+  { text: 'BUKIT MERTAJAM', id: 'P' },
+  { text: 'BERTAM', id: 'P2' },
+  { text: 'PERMATANG PAUH', id: 'P4' },
+  { text: 'SAMARAHAN', id: 'Q' },
+  { text: 'SAMARAHAN 2', id: 'Q5' },
+  { text: 'MUKAH', id: 'Q6' },
+  { text: 'ARAU', id: 'R' },
+  { text: 'KOTA KINABALU', id: 'S' },
+  { text: 'TAWAU', id: 'S2' },
+  { text: 'DUNGUN', id: 'T' },
+  { text: 'BUKIT BESI', id: 'T4' },
+  { text: 'KUALA TERENGGANU', id: 'T5' },
+];
+
+async function getSessionKeys(client, jar) {
+  await client.get(BASE);
+  const cookieList = await jar.getCookies(BASE);
+  let key1 = "", key2 = "", key3 = "";
+  for (const c of cookieList) {
+    if (c.key === "KEY1") key1 = c.value;
+    if (c.key === "KEY2") key2 = c.value;
+    if (c.key === "KEY3") key3 = c.value;
+  }
+  return { key1, key2, key3 };
+}
+
+async function getCourseList(client, campusId, key1, key2, key3) {
+  const payload = {
+    "captcha_no_type": "llIlllIlIIllIlIIIIlllIlIll",
+    "captcha1": "lIIlllIlIllIllIIIIIlIlllllIlIll",
+    "captcha2": "lIIlllIlIllIlIIlIllIIIIlllIllll",
+    "captcha3": "lIIlllIlIllIlIIlIllIIIIlllIllll",
+    "token1": "lIIlllIlIllIllIIIIIlIlllllIlIll",
+    "token2": "lIIlllIlIllIlIIlIllIIIIlllIllll",
+    "token3": "lIIlllIlIllIlIIlIllIIIIlllIllll",
+    "llIlllIlIIllIlIIIIlllIlIll": "lIIlllIlIllIlIIlIllIlIIIlllIlIll",
+    "llIlllIlIIlllllIIIlllIlIll": "lIIllIlIlllIlIIlIllIIIIllllIlIll",
+    "lIIlllIlIIlIllIIIIlllIlIll": "lIIlllIlIIIlllIIIIlIllIlllIlIll",
+    "lIIlIlllIlIIllIlIIIIlllIlIllI": "lIIlIlllIlIIllIlIIIIlllIlIlllI",
+    "lIIlIlllIlIIllIllIlIIIIlllIlIllI": "lIIlIlllIlIIllIllIlIIIIlllIlIllI",
+    "lIIlIlllIlIIllIlIIIIlllIlIlllIlIllI": "lIIlIlllIlIIllIlIIIIlllIlIlllIlIllI",
+    "lIIlIllIlIllllIlIIllIlIIIIlllIlIllI": "lIIlIllIlIllllIlIIllIlIIIIlllIlIllI",
+    "lIIlIlllIlIIllllIlIIllIlIIIIlllIlIllI": "lIIlIlllIlIIllllIlIIllIllIIIIlllIlIllI",
+    "lIIlIlllIlIIIlIlllIlIIllIlIIIIlllIlIllI": "lIllIlllIlIIIlIlllIlIIllIlIIIIlllIlIllI",
+    "lIIlIlllIlIIllIlIIIlIIllIlIIIIlllIlIllI": "lIIlIlllIlIIllIlIlIIlIIllIlIIIIlIlIllllI",
+    "llIIlIlllIlIIllIlIIIlIIllIlIIIIlllIlIllI": "lIIlIlllIlIIllIlIIIlIIllIlIIIIlllIlIllI",
+    "lllIIlIlllIlIIllIlIIIlIIllIlIIIIlllIlIllI": "lIIlIlllIlIIllIlIIIlIIllIlIIIIlllIlIllI",
+    "llllIIlIlllIlIIllIlIIIlIIllIlIIIIlllIlIllI": "lIIlIlllIlIIllIlIIIlIIllIlIIIIlllIlIllI",
+    "llllIIlIlllIlIIlllllIIIlIIllIlIIIIlllIlIllIl": "llllIIlIlllIlIIlllllIIIlIIllIlIIIIlllIlIllI",
+    "search_campus": campusId,
+    "search_course": "",
+    "lIIIlllIIllll": "lIIIlllIIllll"
+  };
+
+  const url = `${BASE}INDEX_RESULT_lII1II11I1lIIII11IIl1I111I.cfm?id1=${key1}&id2=${key2}&id3=${key3}`;
+  const res = await client.post(url, new URLSearchParams(payload).toString(), {
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "User-Agent": "Mozilla/5.0",
+      Referer: `${BASE}index.htm`,
+    },
+  });
+
+  const $ = cheerio.load(res.data);
+  const courses = [];
+  $("tr.gradeU").each((i, row) => {
+    const code = $(row).find("td:nth-child(2)").text().trim();
+    const href = $(row).find("a").attr("href");
+    if (code && href) courses.push({ code, href });
+  });
+  return courses;
+}
+
+async function getClassInfo(client, href) {
+  const url = `${BASE}${href}`;
+  const res = await client.get(url, {
+    headers: { "User-Agent": "Mozilla/5.0", Referer: `${BASE}index.htm` },
+  });
+
+  const $ = cheerio.load(res.data);
+  const rows = [];
+  $("#example tbody tr").each((_, tr) => {
+    const cells = $(tr).find("td");
+    if (cells.length > 0) {
+      rows.push({
+        day_time: $(cells[1]).text().trim(),
+        group: $(cells[2]).text().trim(),
+        mode: $(cells[3]).text().trim(),
+        status: $(cells[4]).text().trim(),
+        room: $(cells[5]).text().trim(),
+        program: $(cells[6]).text().trim(),
+        faculty: $(cells[7]).text().trim(),
+      });
+    }
+  });
+  return rows;
+}
+
+async function scrapeCampus(campus) {
+  const jar = new CookieJar();
+  const client = wrapper(axios.create({ jar, withCredentials: true }));
+
+  const { key1, key2, key3 } = await getSessionKeys(client, jar);
+  const courses = await getCourseList(client, campus.id, key1, key2, key3);
+
+  const result = {};
+  for (let i = 0; i < courses.length; i++) {
+    const { code, href } = courses[i];
+    try {
+      const classes = await getClassInfo(client, href);
+      result[code] = classes;
+      process.stdout.write(`\r  [${i + 1}/${courses.length}] ${code}          `);
+    } catch (err) {
+      result[code] = [];
+    }
+    await delay(400);
+  }
+
+  return { courses: courses.length, result };
+}
+
+async function main() {
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+
+  console.log(`🚀 Starting full scrape for ${CAMPUSES.length} campuses...\n`);
+
+  const summary = [];
+
+  for (const campus of CAMPUSES) {
+    console.log(`\n📍 Campus: ${campus.id} (${campus.text})`);
+    try {
+      const { courses, result } = await scrapeCampus(campus);
+      const outputPath = `${OUTPUT_DIR}/${campus.id}.json`;
+      writeFileSync(outputPath, JSON.stringify(result, null, 2));
+      console.log(`\n  ✅ Done — ${courses} courses saved to ${outputPath}`);
+      summary.push({ campus: campus.id, name: campus.text, courses, status: "ok" });
+    } catch (err) {
+      console.log(`\n  ❌ Failed — ${err.message}`);
+      summary.push({ campus: campus.id, name: campus.text, courses: 0, status: "error", error: err.message });
+    }
+
+    await delay(1000); // wait 1s between campuses
+  }
+
+  // Save summary
+  writeFileSync(`${OUTPUT_DIR}/index.json`, JSON.stringify({
+    scraped_at: new Date().toISOString(),
+    campuses: summary
+  }, null, 2));
+
+  console.log("\n\n=== SUMMARY ===");
+  console.table(summary.map(r => ({ campus: r.campus, name: r.name, courses: r.courses, status: r.status })));
+  console.log(`\n✅ All done! Files saved to ${OUTPUT_DIR}/`);
+}
+
+main().catch(console.error);

--- a/testScripts/class.js
+++ b/testScripts/class.js
@@ -4,7 +4,7 @@ import * as cheerio from "cheerio";
 async function scrape() {
   const url =
     `
-   https://simsweb4.uitm.edu.my/estudent/class_timetable/index_tt.cfm?id1=4DAB6C9682B3A7FBA90731BE9DB03B821F&id3=B6C9683&id2=7604AEE5A274AED3EB43CD559296E6904E
+   https://simsweb4.uitm.edu.my/estudent/class_timetable/index_tt.cfm?id1=56E7D793CF6FBE19EFCF651986FFCA56AFBD&id3=7D793C3&id2=67FBD49796F2EC99FED70E99845F8442CABA
     `;
 
   const res = await axios.get(url, {
@@ -37,7 +37,7 @@ async function scrape() {
 });
 
 console.log(rows.map(r => r.class_code)); 
-  //console.log(JSON.stringify(rows, null, 2));
+  console.log(JSON.stringify(rows, null, 2));
 }
 
 scrape().catch(console.error);

--- a/testScripts/timetable.js
+++ b/testScripts/timetable.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 async function scrape() {
-  const url = "https://cdn.uitm.link/jadual/baru/2026118031.json";
+  const url = "https://cdn.uitm.link/jadual/baru/2026121623.json";
 
   const res = await axios.get(url, {
     headers: {


### PR DESCRIPTION
## Summary

- Add `scripts/scraperAll.js` — scrapes all 32 UiTM campuses, fetches every course and class group, saves output as JSON to `public/timetable/{campusId}.json`
- Add `public/timetable/index.json` — summary file with scrape timestamp and per-campus course counts
- Update `.github/workflows/scrape.yml` to reference `scripts/scraperAll.js` (moved out of gitignored `testScripts/`)
- Cron runs on the **1st of every month**, can also be triggered manually from GitHub Actions UI

## How it works

1. GitHub Actions wakes up on schedule
2. Runs `scripts/scraperAll.js` which scrapes all 32 campuses (~8,000+ courses total)
3. Saves JSON files to `public/timetable/`
4. Commits and pushes back to repo
5. Vercel detects new commit and auto-redeploys with fresh data

## Reviewer notes

- `testScripts/` is gitignored — all scraper logic has been moved to `scripts/` to be tracked
- Delay between requests is 400ms per course, 1s between campuses to avoid rate limiting
- Each campus gets its own JSON file e.g. `public/timetable/A4.json`
- Zero Redis required — static JSON served directly from `public/`